### PR TITLE
An error on redirecting address has been fixed

### DIFF
--- a/public/.htaccess.dist
+++ b/public/.htaccess.dist
@@ -6,6 +6,6 @@ RewriteCond %{REQUEST_FILENAME} -s [OR]
 RewriteCond %{REQUEST_FILENAME} -l [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^.*$ - [NC,L]
-RewriteRule ^.*$ /vimbadmin/index.php [NC,L]
+RewriteRule ^.*$ index.php [NC,L]
 
 


### PR DESCRIPTION
the addressing file is wrong, the apache2.4 will raise an error saying `AH00124: Request exceeded the limit of 10 internal redirects due to probable configuration error. Use 'LimitInternalRecursion' to increase the limit if necessary. Use 'LogLevel debug' to get a backtrace.` which is due to the redirecting address, by fixing this, everything will work file